### PR TITLE
A better solution for language change

### DIFF
--- a/app/src/main/java/com/example/quicksellapp/MainActivity.kt
+++ b/app/src/main/java/com/example/quicksellapp/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.example.quicksellapp
 
+import android.content.Context
+import android.content.ContextWrapper
 import android.os.Build
 import android.os.Bundle
 import androidx.databinding.DataBindingUtil
@@ -9,7 +11,6 @@ import com.example.quicksellapp.extensions.get
 import com.example.quicksellapp.extensions.lastFragment
 import com.example.quicksellapp.screens.home.HomeFragment
 import java.util.*
-import android.os.Build.VERSION_CODES.N
 import android.view.*
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -20,26 +21,27 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setupAppLanguage()
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
         binding.lifecycleOwner = this
         setupToolbar()
         setupNavigationDrawer()
         this.addFragmentOnTop(HomeFragment(), Constants.HOME_SCREEN_TAG)
     }
-    
-    private fun setupAppLanguage() {
-        val sharedPreferences =
-            getSharedPreferences(Constants.SHARED_PREFERENCES_NAME, MODE_PRIVATE)
-        val config = resources.configuration
-        val lang = sharedPreferences.get(Constants.PREFERENCES_LANGUAGE_KEY, Constants.LOCALE_EN)
-        val locale = Locale(lang)
-        Locale.setDefault(locale)
-        config.setLocale(locale)
 
-        if (Build.VERSION.SDK_INT >= N)
-            createConfigurationContext(config)
-        resources.updateConfiguration(config, resources.displayMetrics)
+    override fun attachBaseContext(newBase: Context?) {
+        val sharedPreferences =
+            newBase?.getSharedPreferences(Constants.SHARED_PREFERENCES_NAME, MODE_PRIVATE)
+        val lang = sharedPreferences?.get(Constants.PREFERENCES_LANGUAGE_KEY, Constants.LOCALE_EN)
+        super.attachBaseContext(ContextWrapper(newBase?.setAppLocale(lang ?: Constants.LOCALE_EN)))
+    }
+
+    private fun Context.setAppLocale(language: String): Context {
+        val locale = Locale(language)
+        Locale.setDefault(locale)
+        val config = resources.configuration
+        config.setLocale(locale)
+        config.setLayoutDirection(locale)
+        return createConfigurationContext(config)
     }
 
     private fun setupToolbar() {


### PR DESCRIPTION
- uses only the create configuration context the moment the base context is attached
- no more use of deprecated tools